### PR TITLE
🎨 Drawing 3D plot keeping the original colours

### DIFF
--- a/scSLAT/viz/multi_dataset.py
+++ b/scSLAT/viz/multi_dataset.py
@@ -82,7 +82,7 @@ class build_3D():
         self.loc_list = []
         self.anno_list = []
         for adata in adatas:
-            loc = adata.obsm[spatial_key]
+            loc = adata.obsm[spatial_key].copy()
             if scale_coordinate:
                 for i in range(2):
                     loc[:,i] = (loc[:,i]-np.min(loc[:,i]))/(np.max(loc[:,i])-np.min(loc[:,i]))


### PR DESCRIPTION
Dear SLAT Authors,

I noticed that when we use the `build_3D` function to visualize the alignment effects, the original idle annotation colors are discarded. It seems this is done to unify the color information of annotations at the same spatial location.

In this pull request, I have preserved the color information. I believe that unifying the color information of annotations at the same spatial location should be done during annotation, not at the final visualization stage.

Additionally, it seems that after using `build_3D`, `plt.savefig()` cannot be used to save the image. I have made `ax` a return value to address this issue.

<img width="372" alt="image" src="https://github.com/gao-lab/SLAT/assets/46667721/c8bd2458-742a-4236-949d-913b3df05fed">
